### PR TITLE
Do not run hook when importing data from t3d

### DIFF
--- a/Classes/Hooks/DataHandler.php
+++ b/Classes/Hooks/DataHandler.php
@@ -42,7 +42,7 @@ class DataHandler
      * @param \TYPO3\CMS\Core\DataHandling\DataHandler $parentObject
      */
     public function processDatamap_afterDatabaseOperations($operation, $table, $id, array $fields, \TYPO3\CMS\Core\DataHandling\DataHandler $parentObject) {
-        if ($table === 'sys_file_metadata') {
+        if ($table === 'sys_file_metadata' && !$parentObject->isImporting) {
             if (!is_numeric($id)) {
                 $id = $parentObject->substNEWwithIDs[$id];
             }


### PR DESCRIPTION
This hook was breaking file import when importing data from t3d.
error was: "Could not find row with UID "0" in table "sys_file""