### PR TITLE
Improve error handling

### DIFF
--- a/Classes/Controller/FileController.php
+++ b/Classes/Controller/FileController.php
@@ -155,7 +155,7 @@ class FileController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
                     $this->populateFromFileCollections($files);
                     break;
             }
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             return $this->error('The configuration of the file_list plugin is incorrect: ' . $e->getMessage());
         }
 


### PR DESCRIPTION
Up to now only Exception would be catched in list action. Under certain circumstances like an invalid folder path with t3:// syntax also Errors can be thrown. With this change from catching exceptions to catching throwables also errors are catched.