### PR TITLE
[BUGFIX] Files from multiple collections not merged correctly

### DIFF
--- a/Classes/Controller/FileController.php
+++ b/Classes/Controller/FileController.php
@@ -388,7 +388,7 @@ class FileController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
                 /** @var \TYPO3\CMS\Core\Resource\File[] $collectionFiles */
                 $collectionFiles = $collection->getItems();
                 if (empty($folders)) {
-                    $files += $collectionFiles;
+                    $files = array_merge($files, $collectionFiles);
                 } else {
                     foreach ($collectionFiles as $file) {
                         $success = false;


### PR DESCRIPTION
Files from multiple collections are not merged properly, usage of the + operator makes it so the first n files in $collectionFiles are lost (n being the amount of files in the $files-array).
