### PR TITLE
[BUGFIX] Prevent accessing null object

### DIFF
--- a/Classes/Controller/FileController.php
+++ b/Classes/Controller/FileController.php
@@ -209,7 +209,7 @@ class FileController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
             /** @var LinkService $linkService */
             $linkService = GeneralUtility::makeInstance(LinkService::class);
             $data = $linkService->resolveByStringRepresentation($identifier);
-            if ($data['type'] === 'folder') {
+            if ($data['type'] === 'folder' && $data['folder'] !== null) {
                 /** @var \TYPO3\CMS\Core\Resource\Folder $folder */
                 $folder = $data['folder'];
                 $identifier = 'file:' . $folder->getCombinedIdentifier();


### PR DESCRIPTION
It can happen that a folder is referenced that has been deleted from the file system, thus leading to an exception when trying to access `$data['folder']->getCombinedIdentifier()`. This patch mitigates this error.