### PR TITLE
Bugfix: urldecode folders paths

### DIFF
--- a/Classes/Updates/PathUpdater.php
+++ b/Classes/Updates/PathUpdater.php
@@ -57,7 +57,7 @@ class PathUpdater implements UpgradeWizardInterface
             $flexFormData = GeneralUtility::xml2array($row['pi_flexform']);
             $path = &$flexFormData['data']['sDEF']['lDEF']['settings.path']['vDEF'] ?? '';
             if (preg_match('#^t3://folder\?storage=(\d+)&identifier=(.*)$#', $path, $matches)) {
-                $path = $matches[1] . ':' . $matches[2];
+                $path = $matches[1] . ':' . urldecode($matches[2]);
                 $newFlexFormData = $flexFormTools->flexArray2Xml($flexFormData, true);
 
                 $tableConnection->update(


### PR DESCRIPTION
%2F needs to be replaced with / in example path: t3://folder?storage=1&identifier=%2Fmedia%2Ftest%2F

else, I get an error message in the frontend "The configuration of the file_list plugin is incorrect" and in BE the plugin shows no path in edit view