### PR TITLE
Adapt updates registration for V13 of TYPO3

### DIFF
--- a/Classes/Updates/PathUpdater.php
+++ b/Classes/Updates/PathUpdater.php
@@ -21,16 +21,13 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
+#[UpgradeWizard('fileList_pathUpdater')]
 class PathUpdater implements UpgradeWizardInterface
 {
-    public function getIdentifier(): string
-    {
-        return 'TxFileListPath';
-    }
-
     public function getTitle(): string
     {
         return 'EXT:file_list: Migrate path definition since TYPO3 v12';

--- a/Classes/Updates/PathUpdater.php
+++ b/Classes/Updates/PathUpdater.php
@@ -50,7 +50,7 @@ class PathUpdater implements UpgradeWizardInterface
 
         $rows = $queryBuilder
             ->select('*')
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
 
         foreach ($rows as $row) {
@@ -81,7 +81,7 @@ class PathUpdater implements UpgradeWizardInterface
 
         return $ttContentQueryBuilder
             ->count('*')
-            ->execute()
+            ->executeQuery()
             ->fetchOne() > 0;
     }
 

--- a/Classes/Updates/PluginsUpdater.php
+++ b/Classes/Updates/PluginsUpdater.php
@@ -20,16 +20,13 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Install\Attribute\UpgradeWizard;
 use TYPO3\CMS\Install\Updates\DatabaseUpdatedPrerequisite;
 use TYPO3\CMS\Install\Updates\UpgradeWizardInterface;
 
+#[UpgradeWizard('fileList_pluginsUpdater')]
 class PluginsUpdater implements UpgradeWizardInterface
 {
-    public function getIdentifier(): string
-    {
-        return 'TxFileListPlugins';
-    }
-
     public function getTitle(): string
     {
         return 'EXT:file_list: Migrate plugins';

--- a/Classes/Updates/PluginsUpdater.php
+++ b/Classes/Updates/PluginsUpdater.php
@@ -48,7 +48,7 @@ class PluginsUpdater implements UpgradeWizardInterface
 
         $rows = $queryBuilder
             ->select('*')
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
 
         foreach ($rows as $row) {
@@ -70,7 +70,7 @@ class PluginsUpdater implements UpgradeWizardInterface
 
         $rows = $queryBuilder
             ->select('*')
-            ->execute()
+            ->executeQuery()
             ->fetchAllAssociative();
 
         foreach ($rows as $row) {
@@ -106,11 +106,11 @@ class PluginsUpdater implements UpgradeWizardInterface
 
         $recordsToUpdate = $ttContentQueryBuilder
             ->count('*')
-            ->execute()
+            ->executeQuery()
             ->fetchOne();
         $recordsToUpdate += $beGroupsQueryBuilder
             ->count('*')
-            ->execute()
+            ->executeQuery()
             ->fetchOne();
 
         return $recordsToUpdate > 0;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -46,12 +46,4 @@ defined('TYPO3') || die();
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][$_EXTKEY] = \Causal\FileList\Hooks\DataHandler::class;
 
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['routing']['aspects']['FileListFolderMapper'] = \Causal\FileList\Routing\Aspect\FileListFolderMapper::class;
-
-    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['TxFileListPlugins']
-        = \Causal\FileList\Updates\PluginsUpdater::class;
-
-    if ($typo3Version >= 12) {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['ext/install']['update']['TxFileListPath']
-            = \Causal\FileList\Updates\PathUpdater::class;
-    }
 })('file_list');


### PR DESCRIPTION
Hello,

While updating a TYPO3 from v11 to v13 I realized that the updaters were not available in the backend.

In addition, the updaters were not executing due to the execute() functions.
So I made the changes based on this documentation: [Creating upgrade wizards](https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ExtensionArchitecture/HowTo/UpdateExtensions/UpdateWizards/Creation.html)

These changes may not be supported in v10 and v11 and I want to notice that in the composer.json this version are also supported

Best regards,
Astrit Aslani